### PR TITLE
Cannot find module 'ssh-keygen' fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "bluebird": "^2.9.32",
     "fs-extra": "^0.24.0",
     "lodash": "^3.9.3",
-    "restler": "^3.3.0"
+    "restler": "^3.3.0",
+    "ssh-fingerprint": "0.0.1",
+    "ssh-keygen": "^0.2.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -28,8 +30,6 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-jscs": "~0.8.1",
     "jshint-stylish": "~1.0.0",
-    "ssh-fingerprint": "0.0.1",
-    "ssh-keygen": "^0.2.1",
     "matchdep": "^0.3.0"
   }
 }


### PR DESCRIPTION
Installed master as you suggested, tried to provision, I get this:

```
john@kalamuna:~/kb2$ kbox provision -- -d=150000
kalabox-app-pantheon -> Cannot find module 'ssh-keygen'
Error: kalabox-app-pantheon -> Cannot find module 'ssh-keygen'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```

This patch fixes my sadness 
