### PR TITLE
Pipe from gzip to database to avoid temp file + zip file support

### DIFF
--- a/app/dockerfiles/pantheon-mariadb/import.sh
+++ b/app/dockerfiles/pantheon-mariadb/import.sh
@@ -19,11 +19,15 @@ fi
 MYSQL_OPTS="-u pantheon ${OPT_DB_PASSWORD}-h ${DB_HOST} -P ${DB_PORT} pantheon"
 
 # "Switch" on file extension
-# @todo: Handle different formats?
 if [[ $ARCHIVE == *gz ]]; then
   gzip -cd "${ARCHIVE}" | mysql $MYSQL_OPTS
+elif [[ $ARCHIVE == *zip ]]; then
+  unzip -p "${ARCHIVE}" | mysql $MYSQL_OPTS
 elif [[ $ARCHIVE == *sql ]]; then
   mysql $MYSQL_OPTS < "${ARCHIVE}"
+else
+  >&2 echo "ERROR Unsupported input format: ${ARCHIVE}"
+  exit 1
 fi
 
 rm -f "${ARCHIVE}"

--- a/app/dockerfiles/pantheon-mariadb/import.sh
+++ b/app/dockerfiles/pantheon-mariadb/import.sh
@@ -7,25 +7,23 @@ DB_PASSWORD="$2"
 DB_PORT="$3"
 ARCHIVE="$4"
 
-# @todo: Handle difference formats?
-# [[ $a == z* ]]
-if [[ $ARCHIVE == *gz ]]; then
-  echo "Extracting ${ARCHIVE}"
-  gunzip -df "${ARCHIVE}"
-  SUFFIX=".gz"
-  SQL=${ARCHIVE%$SUFFIX}
-elif [[ $ARCHIVE == *sql ]]; then
-  echo "USING EXISTING ${ARCHIVE}"
-  SQL=${ARCHIVE}
-fi
-
 # @todo: Handle different DBs?
+echo "Importing ${ARCHIVE} to ${DB_HOST}"
 
-echo "Importing ${SQL} to ${DB_HOST}"
-if [ -z "$DB_PASSWORD" ]; then
-  mysql -u pantheon -h "${DB_HOST}" -P "${DB_PORT}" pantheon < "${SQL}"
-else
-  mysql -u pantheon -p"${DB_PASSWORD}" -h "${DB_HOST}" -P "${DB_PORT}" pantheon < "${SQL}"
+# Use password option if password is specified.
+OPT_DB_PASSWORD=""
+if [ ! -z "$DB_PASSWORD" ]; then
+  OPT_DB_PASSWORD="-p${DB_PASSWORD} "
 fi
 
-rm -f "${SQL}"
+MYSQL_OPTS="-u pantheon ${OPT_DB_PASSWORD}-h ${DB_HOST} -P ${DB_PORT} pantheon"
+
+# "Switch" on file extension
+# @todo: Handle different formats?
+if [[ $ARCHIVE == *gz ]]; then
+  gzip -cd "${ARCHIVE}" | mysql $MYSQL_OPTS
+elif [[ $ARCHIVE == *sql ]]; then
+  mysql $MYSQL_OPTS < "${ARCHIVE}"
+fi
+
+rm -f "${ARCHIVE}"


### PR DESCRIPTION
Kalabox can avoid uncompressed SQL files by piping gzip directly into mysql. Doesn't really matter for smaller sites, but can make a huge difference on the large ones. 4GB SQL files, for example, waste lots of disk space and write/read time.

Plus! I added support for zip files and an error if the format is unsupported. Can put in a separate PR if you want, but it's tiny and an easy addon.

Notes/Q:
- Removed extraneous double quotes; host, port, password (using -p), and username cannot contain whitespace.
- Should it have a file existence check?
