### PR TITLE
Add ports 80/443 to nginx configuration files

### DIFF
--- a/app/config/nginx/backdrop.conf
+++ b/app/config/nginx/backdrop.conf
@@ -1,6 +1,8 @@
 server {
   listen 8888 default_server;
+  listen 80 default_server;
   listen 444 ssl;
+  listen 443 ssl;
 
   server_name appserver;
 

--- a/app/config/nginx/drupal.conf
+++ b/app/config/nginx/drupal.conf
@@ -1,6 +1,8 @@
 server {
   listen 8888 default_server;
+  listen 80 default_server;
   listen 444 ssl;
+  listen 443 ssl;
 
   server_name appserver;
 

--- a/app/config/nginx/drupal8.conf
+++ b/app/config/nginx/drupal8.conf
@@ -1,6 +1,8 @@
 server {
   listen 8888 default_server;
+  listen 80 default_server;
   listen 444 ssl;
+  listen 443 ssl;
 
   server_name appserver;
 

--- a/app/config/nginx/wordpress.conf
+++ b/app/config/nginx/wordpress.conf
@@ -1,6 +1,8 @@
 server {
   listen 8888 default_server;
+  listen 80 default_server;
   listen 444 ssl;
+  listen 443 ssl;
 
   server_name appserver;
 


### PR DESCRIPTION
Trying to access http://whatever.kbox from inside the appserver container failed, because it was attempting to connect on ports 80/443, but nginx was only listening on ports 8888/444.  

This adds those ports to the 4 nginx configuration files. 

Issue details: kalabox/kalabox#1090
