### PR TITLE
PhantomJS bitbucket URL --> github URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-v0.12.0-beta3
-============
-
-#### New Features
-
-
-
-#### Bug Fixes
-
-* Fixed a redis typo in kalabox-compose.yml
-* Changed to a more robust PhantomJS download URL provided by Medium within their wrapper for installing via npm on github. [#1359](https://github.com/kalabox/kalabox/issues/1359)
-
 v0.12.0-beta2
 =============
 
@@ -23,6 +11,8 @@ v0.12.0-beta2
 * Fixed bug where you couldn't read properties `git_url` and `id` [#1318](https://github.com/kalabox/kalabox/issues/1318)
 * Improved deployment [#1223](https://github.com/kalabox/kalabox/issues/1223)
 * Added tests to make sure we remove testing SSH keys from Pantheon. [#1321](https://github.com/kalabox/kalabox/issues/1321)
+* Fixed a redis typo in kalabox-compose.yml
+* Changed to a more robust PhantomJS download URL provided by Medium within their wrapper for installing via npm on github. [#1359](https://github.com/kalabox/kalabox/issues/1359)
 
 v0.12.0-beta1
 =============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ v0.12.0-beta2
 * Added tests to make sure we remove testing SSH keys from Pantheon. [#1321](https://github.com/kalabox/kalabox/issues/1321)
 * Fixed a redis typo in kalabox-compose.yml
 * Changed to a more robust PhantomJS download URL provided by Medium within their wrapper for installing via npm on github. [#1359](https://github.com/kalabox/kalabox/issues/1359)
+* Fixed an issue where the build process was not perserving script executable permissions [#1341](https://github.com/kalabox/kalabox/issues/1341)
 
 v0.12.0-beta1
 =============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v0.12.0-beta3
 #### Bug Fixes
 
 * Fixed a redis typo in kalabox-compose.yml
+* Changed to a more robust PhantomJS download URL provided by Medium within their wrapper for installing via npm on github. [#1359](https://github.com/kalabox/kalabox/issues/1359)
 
 v0.12.0-beta2
 =============

--- a/app/dockerfiles/pantheon-appserver/Dockerfile
+++ b/app/dockerfiles/pantheon-appserver/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   dpkg -i /tmp/wkhtmltox-0.12.2_linux-jessie-amd64.deb && \
   mkdir -p /srv/bin && ln -s /usr/local/bin/wkhtmltopdf /srv/bin/wkhtmltopdf && \
   cd /srv/bin && \
-  curl -fsSL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2" | tar -xjv && \
+  curl -fsSL "https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2" | tar -xjv && \
   mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /srv/bin/phantomjs && \
   rm -rf phantomjs-2.1.1-linux-x86_64 && rm -f phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
   chmod +x /srv/bin/phantomjs && \

--- a/app/dockerfiles/pantheon-appserver/README.md
+++ b/app/dockerfiles/pantheon-appserver/README.md
@@ -44,7 +44,7 @@ RUN \
   dpkg -i /tmp/wkhtmltox-0.12.2_linux-jessie-amd64.deb && \
   mkdir -p /srv/bin && ln -s /usr/local/bin/wkhtmltopdf /srv/bin/wkhtmltopdf && \
   cd /srv/bin && \
-  curl -fsSL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2" | tar -xjv && \
+  curl -fsSL "https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2" | tar -xjv && \
   mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /srv/bin/phantomjs && \
   rm -rf phantomjs-2.1.1-linux-x86_64 && rm -f phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
   chmod +x /srv/bin/phantomjs && \


### PR DESCRIPTION
@pirog [#1359](https://github.com/kalabox/kalabox/issues/1359)

Here's the pull for the link to the most popular raw PhantomJS compressed file for npm instead of download limited bitbucket. Strange that the "Medium" publishing company is responsible for it. But, whatever.

Thank you so much for contributing code to Kalabox!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**
- [ Probably] My code passes relevant CI status checks
- [ N--Maybe it should] My code includes a test ([see here](https://github.com/kalabox/kalabox-app-php/blob/HEAD/CONTRIBUTING.md))
- [ Y ] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox-app-php/blob/HEAD/CHANGELOG.md))
- [ Yes in the README.md ] My code includes documentation updates if relevant.
- [ Yes ] I have pinged @pirog when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
