### PR TITLE
Removed explicit database prefix to allow for manual override.

### DIFF
--- a/app/plugins/kalabox-plugin-pantheon/lib/env.js
+++ b/app/plugins/kalabox-plugin-pantheon/lib/env.js
@@ -45,7 +45,6 @@ module.exports = function(kbox, app) {
       default: {
         default: {
           driver: 'mysql',
-          prefix: '',
           database: 'pantheon',
           username: 'pantheon',
           password: 'pantheon',


### PR DESCRIPTION
This is in response to a request from @pirog:

> alternatively @tony if you wanted to submit a very basic pull request (instead of an issue) that removes this line
> https://github.com/kalabox/kalabox-app-pantheon/blob/v2.1/app/plugins/kalabox-plugin-pantheon/lib/env.js#L48 that would be awesome