### PR TITLE
Update drupal8.conf try_files line for nginx

### DIFF
--- a/app/config/nginx/drupal8.conf
+++ b/app/config/nginx/drupal8.conf
@@ -72,7 +72,7 @@ server {
 
   location / {
       # auth_basic $auth_basic_realm;
-      try_files $uri $uri/ @cleanurl;
+      try_files $uri $uri/ /index.php?$args;
       # Catch directory listing errors (i.e. no code)
       error_page 403 /403.html;
       # error_page 301 =301 $client_scheme://$host$uri/$is_args$args;


### PR DESCRIPTION
This updates the try_files line in drupal8.conf to match what Pantheon is currently using for Drupal 8.

This resolves an issue I was having where I was getting a stray "q=[current-path]" query string appended to every page on my site due to some sort of redirect issue.

I did not update the changelog for this, wasn't sure if it's significant enough.